### PR TITLE
Make loading current totd from leaderboard fast

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const uri = process.env.MONGODB_URI;
 const app = express();
 const PORT = process.env.PORT || 3000;
 const totdfile = 'totd.json';
+const GROUP_UID_LENS = [8,4,4,4,12];
 
 const client = new MongoClient(uri, {
     serverApi: {
@@ -203,7 +204,7 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async (re
             console.log(args);
             let groupUid = args[1];
             if (groupUid !== 'Personal_Best') {
-                groupUid = groupUid.split('-').map(e => convertBase62ToNumber(e, 16)).join('-');
+                groupUid = groupUid.split('-').map((e, i) => convertBase62ToNumber(e, GROUP_UID_LENS[i], 16)).join('-');
             }
 
             const track_info = {
@@ -214,7 +215,7 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async (re
 
             const lbargs = args[0].split('_');
             if (lbargs[1] ==='totd') {
-                track_info.endTimestamp = convertBase62ToNumber(lbargs[2], 10);
+                track_info.endTimestamp = convertBase62ToNumber(lbargs[2]);
             }
             if (lbargs[lbargs.length - 1] === 'f') {
                 args.push(0);
@@ -243,12 +244,12 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async (re
             const targs = args[0].split('_');
             console.log(targs);
             console.log(args);
-            const groupUid = args[1].split('-').map(e => convertBase62ToNumber(e, 16)).join('-');
+            const groupUid = args[1].split('-').map((e, i) => convertBase62ToNumber(e, GROUP_UID_LENS[i], 16)).join('-');
             let command;
             let track_info;
             if (targs[1] === 'totd') { 
                 command = `Track of the Day - ${args[3]}`;
-                if (Number(convertBase62ToNumber(targs[2], 10)) > Math.floor(Date.now() / 1000)) 
+                if (Number(convertBase62ToNumber(targs[2])) > Math.floor(Date.now() / 1000)) 
                     track_info = await cachingTOTDProvider.getData().catch(err => embeddedErrorMessage(endpoint, err));
                 else track_info = await trackmaniaFacade.getTrackInfo(command, args[2], groupUid).catch(err => embeddedErrorMessage(endpoint, err));
             }

--- a/app.js
+++ b/app.js
@@ -215,11 +215,12 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async (re
             const lbargs = args[0].split('_');
             if (lbargs[1] ==='totd') {
                 track_info.endTimestamp = convertBase62ToNumber(lbargs[2], 10);
-            } else if (lbargs[1] === 'f') {
-                args.push(0)
-            } else if (lbargs[1] === 'l') {
+            }
+            if (lbargs[lbargs.length - 1] === 'f') {
+                args.push(0);
+            } else if (lbargs[lbargs.length - 1] === 'l') {
                 args.push(1000-args[3]);
-            } else if (lbargs[1] === 'p') {
+            } else if (lbargs[lbargs.length - 1] === 'p') {
                 data.values[0].split(';').forEach((e) => {
                     args.push(e);
                 });
@@ -240,18 +241,20 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async (re
         
         else if (args[0].slice(0, 5) === 'track') {
             const targs = args[0].split('_');
-            const groupUid = targs[2].split('-').map(e => convertBase62ToNumber(e, 16)).join('-');
+            console.log(targs);
+            console.log(args);
+            const groupUid = args[1].split('-').map(e => convertBase62ToNumber(e, 16)).join('-');
             let command;
             let track_info;
             if (targs[1] === 'totd') { 
-                command = `Track of the Day - ${args[4]}`;
+                command = `Track of the Day - ${args[3]}`;
                 if (Number(convertBase62ToNumber(targs[2], 10)) > Math.floor(Date.now() / 1000)) 
                     track_info = await cachingTOTDProvider.getData().catch(err => embeddedErrorMessage(endpoint, err));
-                else track_info = await trackmaniaFacade.getTrackInfo(command, groupUid, args[3]).catch(err => embeddedErrorMessage(endpoint, err));
+                else track_info = await trackmaniaFacade.getTrackInfo(command, args[2], groupUid).catch(err => embeddedErrorMessage(endpoint, err));
             }
             else { 
                 command = 'Map Search';
-                track_info = await trackmaniaFacade.getTrackInfo(command, groupUid, args[3]).catch(err => embeddedErrorMessage(endpoint, err));
+                track_info = await trackmaniaFacade.getTrackInfo(command, args[2], groupUid).catch(err => embeddedErrorMessage(endpoint, err));
             }
 
             console.log(track_info);

--- a/trackmania.js
+++ b/trackmania.js
@@ -5,7 +5,6 @@ import * as NodeCache from 'node-cache';
 import * as schedule from 'node-schedule';
 import * as fs from 'node:fs';
 import { convertMillisecondsToFormattedTime as convertMS, convertNumberToBase62 } from './utils.js';
-import { group, time } from 'node:console';
 
 /**
  *  JSON of all trackmania.exchange map tags with ID, Name, and Color associated

--- a/trackmania.js
+++ b/trackmania.js
@@ -5,7 +5,7 @@ import * as NodeCache from 'node-cache';
 import * as schedule from 'node-schedule';
 import * as fs from 'node:fs';
 import { convertMillisecondsToFormattedTime as convertMS, convertNumberToBase62 } from './utils.js';
-import { group } from 'node:console';
+import { group, time } from 'node:console';
 
 /**
  *  JSON of all trackmania.exchange map tags with ID, Name, and Color associated
@@ -383,6 +383,7 @@ export class TrackmaniaExchangeService extends BaseService {
 function toBase64(groupUid, timestamp = undefined) {
     if (timestamp !== undefined)
         timestamp = `_totd_${convertNumberToBase62(timestamp, 10)}`;
+    else timestamp = '_0';
 
     if (groupUid !== 'Personal_Best')
         groupUid = groupUid.split('-').map(e => convertNumberToBase62(e, 16)).join('-');
@@ -587,6 +588,8 @@ export async function leaderboard(live_service, oauth_service, track_info, lengt
         times: [],
     };
 
+    console.log(track_info);
+
     await live_service.getMapLeaderboard(`${track_info.groupUid}/map/${track_info.mapUid}`, length, onlyWorld, offset)
     .then(response => response.forEach(record => {
         lb_info.positions.push(record.position);
@@ -636,7 +639,7 @@ export async function leaderboard(live_service, oauth_service, track_info, lengt
                 type: MessageComponentTypes.BUTTON,
                 style: ButtonStyleTypes.SECONDARY,
                 label: 'First',
-                custom_id: `lb_f;${groupUid};${track_info.mapUid};${length}`,
+                custom_id: `lb${timestamp}_f;${groupUid};${track_info.mapUid};${length}`,
                 disabled: false,
                 emoji: {
                     id: null,
@@ -646,7 +649,7 @@ export async function leaderboard(live_service, oauth_service, track_info, lengt
                 type: MessageComponentTypes.BUTTON,
                 style: ButtonStyleTypes.SECONDARY,
                 label: 'Back',
-                custom_id: `lb;${groupUid};${track_info.mapUid};${length};${Number(offset)-Number(length)}`,
+                custom_id: `lb${timestamp};${groupUid};${track_info.mapUid};${length};${Number(offset)-Number(length)}`,
                 disabled: false,
                 emoji: {
                     id: null,
@@ -656,7 +659,7 @@ export async function leaderboard(live_service, oauth_service, track_info, lengt
                 type: MessageComponentTypes.BUTTON,
                 style: ButtonStyleTypes.SECONDARY,
                 label: 'Next',
-                custom_id: `lb;${groupUid};${track_info.mapUid};${length};${Number(offset)+Number(length)}`,
+                custom_id: `lb${timestamp};${groupUid};${track_info.mapUid};${length};${Number(offset)+Number(length)}`,
                 disabled: false,
                 emoji: {
                     id: null,
@@ -666,7 +669,7 @@ export async function leaderboard(live_service, oauth_service, track_info, lengt
                 type: MessageComponentTypes.BUTTON,
                 style: ButtonStyleTypes.SECONDARY,
                 label: 'Last',
-                custom_id: `lb_l;${groupUid};${track_info.mapUid};${length}`,
+                custom_id: `lb${timestamp}_l;${groupUid};${track_info.mapUid};${length}`,
                 disabled: false,
                 emoji: {
                     id: null,
@@ -701,7 +704,7 @@ export async function leaderboard(live_service, oauth_service, track_info, lengt
             type: MessageComponentTypes.ACTION_ROW,
             components: [{
                 type: MessageComponentTypes.STRING_SELECT,
-                custom_id: `lb_p;${groupUid};${track_info.mapUid}`,
+                custom_id: `lb${timestamp}_p;${groupUid};${track_info.mapUid}`,
                 placeholder: 'Select page',
                 options: pages,
             },],

--- a/utils.js
+++ b/utils.js
@@ -84,10 +84,11 @@ export function convertNumberToBase62(num, base = 10) {
 /**
  * 
  * @param {string} base62 String of your number in Base62
+ * @param {number} [targetLen=0]
  * @param {num} [base=10] Target base for your Base62 number to become
  * @returns {string}
  */
-export function convertBase62ToNumber(base62num, base = 10) {
+export function convertBase62ToNumber(base62num, targetLen = 0, base = 10) {
     let val = 0;
 
     for (let i = 0; i < base62num.length; i++) {
@@ -96,5 +97,5 @@ export function convertBase62ToNumber(base62num, base = 10) {
         val += digit * Math.pow(62, i);
     }
 
-    return val.toString(base);
+    return val.toString(base).padStart(targetLen, '0');
 }

--- a/utils.js
+++ b/utils.js
@@ -58,3 +58,43 @@ export function convertMillisecondsToFormattedTime(milliseconds) {
 
     return formattedTime;
 }
+
+const BASE62_CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+/**
+ * 
+ * @param {string} num 
+ * @param {number} [base=10] Starting base of number. Max is Base-32. Any value higher will come out as Base-32
+ * @returns {string}
+ */
+export function convertNumberToBase62(num, base = 10) {
+    base = parseInt(Math.min(Math.max(base, 2), 32), 10);
+    let decimalVal = parseInt(num, base);
+    let base62Val = '';
+
+    while (decimalVal > 0) {
+        const remainder = decimalVal % 62;
+        base62Val = BASE62_CHARS.charAt(remainder) + base62Val;
+        decimalVal = Math.floor(decimalVal / 62);
+    }
+    
+    return base62Val;
+}
+
+/**
+ * 
+ * @param {string} base62 String of your number in Base62
+ * @param {num} [base=10] Target base for your Base62 number to become
+ * @returns {string}
+ */
+export function convertBase62ToNumber(base62num, base = 10) {
+    let val = 0;
+
+    for (let i = 0; i < base62num.length; i++) {
+        const char = base62num[base62num.length - 1 - i];
+        const digit = BASE62_CHARS.indexOf(char);
+        val += digit * Math.pow(62, i);
+    }
+
+    return val.toString(base);
+}


### PR DESCRIPTION
Puts the endTimestamp from the track_info json into the customid of buttons for the track of the day embed and leaderboards. 

Originally, this wasn't possible because the groupUid and endTimestamp together, as well as the other states stored in the customid took up more space than allowed in the customid field by discord, so I converted the groupUid string and the endTimestamp to a base-62 string to save characters. 

Now, when you press the track info button from the leaderboard, if the leaderboard you are looking at is for the current track of the day, the loading will be faster because it will get the info from the stored totd.json file rather than having to fetch from the nadeo api.