### PR TITLE
add leaderboard for watched accounts + refactors

### DIFF
--- a/trackmania.js
+++ b/trackmania.js
@@ -722,7 +722,7 @@ export class TrackmaniaFacade {
  * @param {JSON} track_json
  * @returns {Promise<JSON>}
  */
-export async function embedTrackInfo(track_json) {
+export function embedTrackInfo(track_json) {
     const { command, title, author, firstPlace, authortime, goldtime, tags, website, stylename, thumbnail, mapUid, provision, mapType } = track_json;
 
     const medal_times = [


### PR DESCRIPTION
* refactors the way that the bot gets trackmania leaderboard info

* adds a field to the leaderboard embed for accounts that a discord user is "watching", stored locally for now, that is called once when the leaderboard embed is first invoked but when updating to new leaderboard pages, the watched accounts field is not updated