### PR TITLE
optimized accountName fetching

### DIFF
--- a/app.js
+++ b/app.js
@@ -167,6 +167,8 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async (re
             });
 
             let track_json;
+            let callbacks = [trackmaniaFacade.getLeaderboard];
+            let callbackArgs = {};
             let dateArg = new Date();
             if (options[0].name === 'past') {
                 const fields = options[0].options;
@@ -176,18 +178,26 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async (re
                     embeddedErrorMessage(RUD_endpoint, Error('Date given is before Trackmania came out, silly :)'));
 
                 const { command, mapUid, groupUid, endTimestamp } = await trackmaniaFacade.trackOfTheDay(dateArg).catch(err => embeddedErrorMessage(RUD_endpoint, err));
-                const api_calls = await Promise.all([
-                    trackmaniaFacade.getTrackInfo(command, mapUid, groupUid),
-                    trackmaniaFacade.getLeaderboard(`Personal_Best/map/${mapUid}`, 1).then(response => response[0].time ),
-                ]);
-                track_json = api_calls[0];
                 track_json.endTimestamp = endTimestamp;
-                track_json.firstPlace = api_calls[1];
+
+                callbacks.unshift(trackmaniaFacade.getTrackInfo);
+                callbackArgs['0'] = [command, mapUid, groupUid];
+                callbackArgs['1'] = [`Personal_Best/map/${mapUid}`, 1];
 
             } else {
                 track_json = await cachingTOTDProvider.getData().catch(err => embeddedErrorMessage(RUD_endpoint, err));
-                track_json.firstPlace = await trackmaniaFacade.getLeaderboard(`Personal_Best/map/${track_json.mapUid}`, 1).then(response => response[0].time );
+                callbackArgs['0'] = [`Personal_Best/map/${track_json.mapUid}`, 1];
             }
+
+            await Promise.all(
+                callbacks.map((callback, i) => callback(...callbackArgs[i]))
+            ).then(response => {
+                if (options[0].name === 'past') {
+                    track_json = response[0];
+                }
+                const wr = response[response.length-1];
+                track_json.firstPlace = wr[Object.keys(wr)[0]].time;
+            });
             
             await DiscordRequest(RUD_endpoint, {
                 method: 'PATCH',
@@ -253,7 +263,7 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async (re
                 if (accountWatchers.hasOwnProperty(userId) && accountWatchers[userId].length > 0) {
                     const mapType = command_queries[command_queries.length-3];
                     const mapId = revertUID(command_queries[command_queries.length-2]);
-                    getLeaderboards.push(trackmaniaFacade.getWatchedAccounts);
+                    getLeaderboards.push(trackmaniaFacade.getWatchedAccountsMapRecords);
                     getLeaderboardsArgs['1'] = [accountWatchers[userId], mapId, mapType];
                 }
 
@@ -261,10 +271,27 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async (re
                     getLeaderboards.map((e, i) => e(...getLeaderboardsArgs[i]))
                 ).catch(err => embeddedErrorMessage(RUD_endpoint, err));
 
-                track_json.leaderboard = leaderboards[0];
+                let mainLeaderboard = leaderboards[0];
+                let watchedLeaderboard = (leaderboards.length > 1) ? leaderboards[1] : [];
+
+                let accounts = [];
+                leaderboards.forEach((leaderboard) => {
+                    accounts = accounts.concat(Object.keys(leaderboard));
+                });
+                const accountNames = await trackmaniaFacade.getAccountName(accounts);
+                accounts.forEach((e, i) => {
+                    if (i < length) {
+                        mainLeaderboard[e].name = accountNames[e];
+                    }
+                    else {
+                        watchedLeaderboard[e].name = accountNames[e];
+                    }
+                });
+
+                track_json.leaderboard = mainLeaderboard;
                 FEGensArgs['0'] = [track_json, length, true, offset];
                 FEGensArgs['1'] = [{ name: `${userName}'s Watched Players`, }];
-                FEGensArgs['1'][0].records = (leaderboards.length > 1) ? leaderboards[1] : [];
+                FEGensArgs['1'][0].records = watchedLeaderboard;
 
                 const FEs = await Promise.all(
                     FEGens.map((e,i) => e(...FEGensArgs[i]))
@@ -293,9 +320,14 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async (re
                 const length = Number(args[0]);
                 const offset = Number(args[1]);
 
-                const leaderboard = await trackmaniaFacade.getLeaderboard(`${track_json.groupUid}/map/${track_json.mapUid}`, length, true, offset);
+                let leaderboard = await trackmaniaFacade.getLeaderboard(`${track_json.groupUid}/map/${track_json.mapUid}`, length, true, offset);
+                const accountIds = Object.keys(leaderboard);
+                const accountNames = await trackmaniaFacade.getAccountName(accountIds);
+                accountIds.forEach(accountId => {
+                    leaderboard[accountId].name = accountNames[accountId];
+                });
 
-                const { records, buttons, pageSelecter } = await trackmaniaFacade.updateLeaderboard(leaderboard, track_json.mapUid, track_json.groupUid, track_json.endTimestamp, length, true, offset);
+                const { records, buttons, pageSelecter } = trackmaniaFacade.updateLeaderboard(leaderboard, track_json.mapUid, track_json.groupUid, track_json.endTimestamp, length, true, offset);
 
                 let embeds = message.embeds;
                 let components = message.components;

--- a/utils.js
+++ b/utils.js
@@ -108,6 +108,6 @@ export function convertNumberToBase(str, fromBase, toBase, targetLen = 0) {
  */
 export function getDate() {
     let date = new Date();
-    date.setUTCHours(-13);
+    date.setUTCHours(-18);
     return date;
 }


### PR DESCRIPTION
*optimized account name fetching when getting a request for the leaderboard by combining the requests for account names of the main leaderboard and account names of the watched leaderboard into a single fetch request.

*changed the way the records are stored from an array of jsons into one giant json, with each key being the accountId of the record

*refactored a little